### PR TITLE
Random page API

### DIFF
--- a/docs/PAGE.md
+++ b/docs/PAGE.md
@@ -49,7 +49,7 @@ The `Page` class has the following properties:
     _infobox!: any; // Stores the infobox in case it is preloaded or called on the page object earlier
     _tables!: Array<any>; // Stores the tables in case it is preloaded or called on the page object earlier
     _intro!: string; // Stores the intro in case it is preloaded or called on the page object earlier
-    _related!: Array<wikiSummary>; // Stores the related info in case it is preloaded or called on the page object earlier
+    _related!: Array<relatedResult>; // Stores the related info in case it is preloaded or called on the page object earlier
 ```
 
 ## Functions
@@ -125,7 +125,7 @@ const html = await page.intro({redirect: false});
 Returns the related pages given for a a page.
 
 ```js
-related = async (pageOptions?: pageOptions): Promise<Array<wikiSummary>>
+related = async (pageOptions?: pageOptions): Promise<relatedResult>
 ```
 - @param [pageOptions][1] - the options for the page
 - @result[wikiSummary][2] - the summary object for the wiki page

--- a/docs/resultTypes.md
+++ b/docs/resultTypes.md
@@ -11,6 +11,9 @@
 - [languageResult](#languageResult)
 - [wikiMediaResult](#wikiMediaResult)
 - [eventResult](#eventResult)
+- [relatedResult](#relatedResult)
+- [titleItem](#titleItem)
+- [mobileSections](#mobileSections)
 
 ### wikiSummary
 
@@ -205,5 +208,93 @@ interface eventResult {
       year?: number
     }
   ]
+}
+```
+
+### relatedResult
+
+The related result.
+```js
+interface relatedResult {
+  pages: Array<wikiSummary>
+}
+```
+
+### titleItem
+
+The title item object for the page
+```js
+interface titleItem {
+  title: string,
+  page_id: number,
+  rev: number,
+  tid: number,
+  namespace: number,
+  user_id: number,
+  user_text: string,
+  timestamp: string,
+  comment: string,
+  tags: Array<string>,
+  restrictions: Array<string>,
+  page_language: string,
+  redirect: boolean
+}
+
+// The result for the random titles query
+interface title {
+  items: Array<titleItem>
+}
+```
+
+### mobileSections
+
+The mobile sections for the page
+
+```js
+interface mobileSections {
+  lead: {
+    ns: number,
+    id: number,
+    revision: string,
+    lastmodified: string,
+    lastmodifier: {
+      user: string,
+      gender: string
+    },
+    displaytitle: string,
+    normalizedtitle: string,
+    wikibase_item: string,
+    description: string,
+    description_source: string,
+    protection: Record<string, unknown>,
+    editable: boolean,
+    languagecount: number,
+    image: {
+      file: string,
+      urls: {
+        320: string,
+        640: string,
+        800: string,
+        1024: string
+      }
+    },
+    issues: Array<htmlText>,
+    geo?: {
+      latitude: string,
+      longitude: string
+    }
+    sections: Array<section>
+  },
+  remaining: {
+    sections: Array<section>
+  }
+}
+
+interface section {
+  id: number,
+  text: string,
+  toclevel: number,
+  line: string,
+  anchor: string
 }
 ```

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -134,10 +134,10 @@ console.log(suggestion); //Returns 'Batman'
 
 ### random()
 
-Returns a random wiki page in any of the available formats. Formats can be `summary`, `title`, `related`, `mobile-sections` or `mobile-sections-lead`. Defaults to summary by default.
+Returns a random wiki page in any of the available formats. Formats can be `summary`, `title`, `html`, `related`, `mobile-sections` or `mobile-sections-lead`. Defaults to summary.
 
 ```js
-random = async (format?: randomFormats): Promise<wikiSummary | title | relatedResult | string>
+random = async (format?: randomFormats): Promise<wikiSummary | title | string | relatedResult | mobileSections>
 ```
 - @param format - the format for the random page
 - @result the random page in requested format

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -134,7 +134,7 @@ console.log(suggestion); //Returns 'Batman'
 
 ### random()
 
-Returns a random wiki page in any of the available formats. Formats can be `summary`, `title`, `html`, `related`, `mobile-sections` or `mobile-sections-lead`. Defaults to summary.
+Returns a random wiki page in any of the available formats. Formats can be `summary`, `title`, `related`, `mobile-sections` or `mobile-sections-lead`. Defaults to summary.
 
 ```js
 random = async (format?: randomFormats): Promise<wikiSummary | title | string | relatedResult | mobileSections>

--- a/docs/wiki.md
+++ b/docs/wiki.md
@@ -10,6 +10,7 @@
     - [languages()](#languages)
     - [setLang()](#setLang)
     - [suggest()](#suggest)
+    - [random()](#random)
     - [Page Methods](#page-methods)
 
 ## Functions
@@ -129,6 +130,24 @@ suggest = async (query: string): Promise<string | null>
 //example
 const suggestion = await wiki.suggest('Batma');
 console.log(suggestion); //Returns 'Batman'
+```
+
+### random()
+
+Returns a random wiki page in any of the available formats. Formats can be `summary`, `title`, `related`, `mobile-sections` or `mobile-sections-lead`. Defaults to summary by default.
+
+```js
+random = async (format?: randomFormats): Promise<wikiSummary | title | relatedResult | string>
+```
+- @param format - the format for the random page
+- @result the random page in requested format
+
+```js
+//example
+const randomSummary = await wiki.random();
+console.log(random); //Returns wikiSummary of a random pageOption
+const randomMobileSections = await wiki.random("mobile-sections");
+console.log(randomMobileSections); // Returns random mobile sections for a page
 ```
 
 ### Page Methods

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,10 +1,11 @@
 import request, { makeRestRequest, setAPIUrl } from './request'
-import { pageOptions, searchOptions, geoOptions, listOptions, eventOptions } from './optionTypes';
+import { pageOptions, searchOptions, geoOptions, listOptions, eventOptions, randomFormats } from './optionTypes';
 import Page, {
     intro, images, html, content, categories, links, coordinates, langLinks,
     references, infobox, tables, summary, related, media
 } from './page';
 import { coordinatesResult, eventResult, geoSearchResult, imageResult, langLinksResult, languageResult, 
+    relatedResult, 
     title, wikiMediaResult, wikiSearchResult, wikiSummary } from './resultTypes';
 import {
     categoriesError,
@@ -245,7 +246,7 @@ wiki.categories = async (title: string, listOptions?: listOptions): Promise<Arra
  * 
  * @experimental
  */
-wiki.related = async (title: string, pageOptions?: pageOptions): Promise<Array<wikiSummary>> => {
+wiki.related = async (title: string, pageOptions?: pageOptions): Promise<relatedResult> => {
     try {
         if (pageOptions?.autoSuggest) {
             title = await setTitleForPage(title);
@@ -532,8 +533,11 @@ wiki.onThisDay = async (eventOptions: eventOptions = {}): Promise<eventResult> =
  * @param format - The desired return format
  * @returns Returns content from a random page
  */
-wiki.random = async (format: string): Promise<wikiSummary | title | string> => {
+wiki.random = async (format?: randomFormats): Promise<wikiSummary | title | relatedResult | string> => {
     try {
+        if(!format){
+            format = 'summary';
+        }
         const path = `page/random/${format}`;
         const result = await makeRestRequest(path);
         return result;

--- a/source/index.ts
+++ b/source/index.ts
@@ -5,7 +5,7 @@ import Page, {
     references, infobox, tables, summary, related, media
 } from './page';
 import { coordinatesResult, eventResult, geoSearchResult, imageResult, langLinksResult, languageResult, 
-    relatedResult, 
+    mobileSections, relatedResult, 
     title, wikiMediaResult, wikiSearchResult, wikiSummary } from './resultTypes';
 import {
     categoriesError,
@@ -533,7 +533,7 @@ wiki.onThisDay = async (eventOptions: eventOptions = {}): Promise<eventResult> =
  * @param format - The desired return format
  * @returns Returns content from a random page
  */
-wiki.random = async (format?: randomFormats): Promise<wikiSummary | title | relatedResult | string> => {
+wiki.random = async (format?: randomFormats): Promise<wikiSummary | title | relatedResult | mobileSections | string> => {
     try {
         if(!format){
             format = 'summary';

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,20 +1,11 @@
-<<<<<<< HEAD
 import request, { makeRestRequest, setAPIUrl } from './request'
 import { pageOptions, searchOptions, geoOptions, listOptions, eventOptions } from './optionTypes';
-||||||| constructed merge base
-import request, { setAPIUrl } from './request'
-import { pageOptions, searchOptions, geoOptions, listOptions } from './optionTypes';
-=======
-import request, { setAPIUrl, makeRestRequest } from './request'
-import { pageOptions, searchOptions, geoOptions, listOptions } from './optionTypes';
->>>>>>> random: add method to get random page URI
 import Page, {
     intro, images, html, content, categories, links, coordinates, langLinks,
     references, infobox, tables, summary, related, media
 } from './page';
 import { coordinatesResult, eventResult, geoSearchResult, imageResult, langLinksResult, languageResult, 
-    wikiMediaResult, 
-    wikiSearchResult, wikiSummary } from './resultTypes';
+    title, wikiMediaResult, wikiSearchResult, wikiSummary } from './resultTypes';
 import {
     categoriesError,
     contentError, coordinatesError, eventsError, geoSearchError, htmlError, imageError, infoboxError,
@@ -541,7 +532,7 @@ wiki.onThisDay = async (eventOptions: eventOptions = {}): Promise<eventResult> =
  * @param format - The desired return format
  * @returns Returns content from a random page
  */
-wiki.random = async (format: string): Promise<any> => {
+wiki.random = async (format: string): Promise<wikiSummary | title | string> => {
     try {
         const path = `page/random/${format}`;
         const result = await makeRestRequest(path);

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,5 +1,13 @@
+<<<<<<< HEAD
 import request, { makeRestRequest, setAPIUrl } from './request'
 import { pageOptions, searchOptions, geoOptions, listOptions, eventOptions } from './optionTypes';
+||||||| constructed merge base
+import request, { setAPIUrl } from './request'
+import { pageOptions, searchOptions, geoOptions, listOptions } from './optionTypes';
+=======
+import request, { setAPIUrl, makeRestRequest } from './request'
+import { pageOptions, searchOptions, geoOptions, listOptions } from './optionTypes';
+>>>>>>> random: add method to get random page URI
 import Page, {
     intro, images, html, content, categories, links, coordinates, langLinks,
     references, infobox, tables, summary, related, media
@@ -524,6 +532,22 @@ wiki.onThisDay = async (eventOptions: eventOptions = {}): Promise<eventResult> =
         return result;
     } catch (error) {
         throw new eventsError(error);
+    }
+}
+
+/**
+ * Returns a random page
+ *
+ * @param format - The desired return format
+ * @returns Returns content from a random page
+ */
+wiki.random = async (format: string): Promise<any> => {
+    try {
+        const path = `page/random/${format}`;
+        const result = await makeRestRequest(path);
+        return result;
+    } catch (error) {
+        throw new Error(error);
     }
 }
 

--- a/source/optionTypes.ts
+++ b/source/optionTypes.ts
@@ -35,4 +35,4 @@ export type eventTypes =
     'all' | 'selected' | 'births' | 'deaths' | 'events' | 'holidays'
 
 export type randomFormats =
-    'title' | 'summary' | 'html' | 'related' | 'mobile-sections' | 'mobile-sections-lead'
+    'title' | 'summary' | 'related' | 'mobile-sections' | 'mobile-sections-lead'

--- a/source/optionTypes.ts
+++ b/source/optionTypes.ts
@@ -35,4 +35,4 @@ export type eventTypes =
     'all' | 'selected' | 'births' | 'deaths' | 'events' | 'holidays'
 
 export type randomFormats =
-    'title' | 'summary' | 'related' | 'mobile-sections' | 'mobile-sections-lead'
+    'title' | 'summary' | 'html' | 'related' | 'mobile-sections' | 'mobile-sections-lead'

--- a/source/optionTypes.ts
+++ b/source/optionTypes.ts
@@ -33,3 +33,6 @@ export interface eventOptions {
 
 export type eventTypes =
     'all' | 'selected' | 'births' | 'deaths' | 'events' | 'holidays'
+
+export type randomFormats =
+    'title' | 'summary' | 'related' | 'mobile-sections' | 'mobile-sections-lead'

--- a/source/page.ts
+++ b/source/page.ts
@@ -1,7 +1,7 @@
 import { categoriesError, contentError, coordinatesError, htmlError, imageError, 
     infoboxError, introError, linksError, mediaError, preloadError, relatedError, summaryError } from './errors';
 import request, { makeRestRequest } from './request';
-import { coordinatesResult, imageResult, langLinksResult, pageResult, wikiMediaResult, wikiSummary } from './resultTypes';
+import { coordinatesResult, imageResult, langLinksResult, pageResult, relatedResult, wikiMediaResult, wikiSummary } from './resultTypes';
 import { setPageId, setPageIdOrTitleParam } from './utils';
 import { listOptions, pageOptions } from './optionTypes';
 import { MSGS } from './messages';
@@ -38,7 +38,7 @@ export class Page {
     _infobox!: any;
     _tables!: Array<any>;
     _intro!: string;
-    _related!: Array<wikiSummary>;
+    _related!: relatedResult;
     _media!: wikiMediaResult;
     constructor(response: pageResult) {
         this.pageid = response.pageid;
@@ -337,7 +337,7 @@ export class Page {
      * 
      * @experimental
      */
-    public related = async (pageOptions?: pageOptions): Promise<Array<wikiSummary>> => {
+    public related = async (pageOptions?: pageOptions): Promise<relatedResult> => {
         try {
             if (!this._related) {
                 const result = await related(this.title, pageOptions?.redirect);
@@ -753,7 +753,7 @@ export const summary = async (title: string, redirect = true): Promise<wikiSumma
  * 
  * @experimental
  */
-export const related = async (title: string, redirect = true): Promise<Array<wikiSummary>> => {
+export const related = async (title: string, redirect = true): Promise<relatedResult> => {
     try {
         const path = 'page/related/' + title.replace(" ", "_");
         const response = await makeRestRequest(path, redirect);

--- a/source/resultTypes.ts
+++ b/source/resultTypes.ts
@@ -163,3 +163,23 @@ export interface eventResult {
     }
   ]
 }
+
+export interface titleItem {
+  title: string,
+  page_id: number,
+  rev: number,
+  tid: number,
+  namespace: number,
+  user_id: number,
+  user_text: string,
+  timestamp: string,
+  comment: string,
+  tags: Array<string>,
+  restrictions: Array<string>,
+  page_language: string,
+  redirect: boolean
+}
+
+export interface title {
+  items: Array<titleItem>
+}

--- a/source/resultTypes.ts
+++ b/source/resultTypes.ts
@@ -114,10 +114,7 @@ export interface mediaResult {
   title: string,
   section_id: number,
   type: string,
-  caption?: {
-    html: string,
-    text: string
-  },
+  caption?: htmlText,
   showInGallery: boolean,
   srcset: Array<srcResult>
 }
@@ -182,4 +179,113 @@ export interface titleItem {
 
 export interface title {
   items: Array<titleItem>
+}
+
+export interface related {
+  pages: Array<relatedItem>
+}
+
+export interface relatedItem {
+  pageid: number,
+  ns: number,
+  index: number,
+  type: string,
+  title: string,
+  displaytitle: string,
+  namespace: {
+    id: number,
+    text: string
+  },
+  wikibase_item: number,
+  titles: {
+    canonical: string,
+    normalized: string,
+    display: string
+  },
+  thumbnail: {
+    source: string,
+    width: number,
+    height: number
+  },
+  originalimage: {
+    source: string,
+    width: number,
+    height: number
+  },
+  lang: string,
+  dir: string,
+  revision: string,
+  tid: string,
+  timestamp: string,
+  description: string,
+  description_source: string,
+  content_urls: {
+    desktop: {
+      page: string,
+      revisions: string,
+      edit: string,
+      talk: string
+    },
+    mobile: {
+      page: string,
+      revisions: string,
+      edit: string,
+      talk: string
+    }
+  },
+  extract: string,
+  extract_html: string,
+  normalizedtitle: string
+}
+
+export interface mobileSections {
+  lead: {
+    ns: number,
+    id: number,
+    revision: string,
+    lastmodified: string,
+    lastmodifier: {
+      user: string,
+      gender: string
+    },
+    displaytitle: string,
+    normalizedtitle: string,
+    wikibase_item: string,
+    description: string,
+    description_source: string,
+    protection: Record<string, unknown>,
+    editable: boolean,
+    languagecount: number,
+    image: {
+      file: string,
+      urls: {
+        320: string,
+        640: string,
+        800: string,
+        1024: string
+      }
+    },
+    issues: Array<htmlText>,
+    geo?: {
+      latitude: string,
+      longitude: string
+    }
+    sections: Array<section>
+  },
+  remaining: {
+    sections: Array<section>
+  }
+}
+
+export interface section {
+  id: number,
+  text: string,
+  toclevel: number,
+  line: string,
+  anchor: string
+}
+
+export interface htmlText {
+  html: string,
+  text: string
 }

--- a/source/resultTypes.ts
+++ b/source/resultTypes.ts
@@ -57,6 +57,8 @@ export interface langLinksResult {
 }
 
 export interface wikiSummary {
+  ns?: number,
+  index?: number,
   type: string,
   title: string,
   displaytitle: string,
@@ -182,60 +184,7 @@ export interface title {
 }
 
 export interface related {
-  pages: Array<relatedItem>
-}
-
-export interface relatedItem {
-  pageid: number,
-  ns: number,
-  index: number,
-  type: string,
-  title: string,
-  displaytitle: string,
-  namespace: {
-    id: number,
-    text: string
-  },
-  wikibase_item: number,
-  titles: {
-    canonical: string,
-    normalized: string,
-    display: string
-  },
-  thumbnail: {
-    source: string,
-    width: number,
-    height: number
-  },
-  originalimage: {
-    source: string,
-    width: number,
-    height: number
-  },
-  lang: string,
-  dir: string,
-  revision: string,
-  tid: string,
-  timestamp: string,
-  description: string,
-  description_source: string,
-  content_urls: {
-    desktop: {
-      page: string,
-      revisions: string,
-      edit: string,
-      talk: string
-    },
-    mobile: {
-      page: string,
-      revisions: string,
-      edit: string,
-      talk: string
-    }
-  },
-  extract: string,
-  extract_html: string,
-  normalizedtitle: string
+  pages: Array<wikiSummary>
 }
 
 export interface mobileSections {

--- a/source/resultTypes.ts
+++ b/source/resultTypes.ts
@@ -183,7 +183,7 @@ export interface title {
   items: Array<titleItem>
 }
 
-export interface related {
+export interface relatedResult {
   pages: Array<wikiSummary>
 }
 

--- a/test/random.test.ts
+++ b/test/random.test.ts
@@ -1,6 +1,6 @@
 import * as request from '../source/request';
 import wiki from "../source/index";
-import { summaryJson } from './samples';
+import { mobileSections, summaryJson, title } from './samples';
 const requestMock = jest.spyOn(request, "makeRestRequest");
 
 afterAll(() => {
@@ -13,10 +13,22 @@ test('Throws error if response is error', async () => {
     expect(err).rejects.toThrowError(Error);
 });
 
-test('Returns summary of random article', async () => {
+test('Returns summary of random article summary', async () => {
     requestMock.mockImplementation(async () => { return summaryJson });
     const result = await wiki.random("summary");
     expect(result).toStrictEqual(summaryJson);
+});
+
+test('Returns summary of random article mobile sections', async () => {
+    requestMock.mockImplementation(async () => { return mobileSections });
+    const result = await wiki.random("mobile-sections");
+    expect(result).toStrictEqual(mobileSections);
+});
+
+test('Returns summary of random article title', async () => {
+    requestMock.mockImplementation(async () => { return title });
+    const result = await wiki.random("title");
+    expect(result).toStrictEqual(title);
 });
 
 test('Request includes arg provided to method', async () => {

--- a/test/random.test.ts
+++ b/test/random.test.ts
@@ -1,0 +1,27 @@
+import * as request from '../source/request';
+import wiki from "../source/index";
+import { summaryJson } from './samples';
+const requestMock = jest.spyOn(request, "makeRestRequest");
+
+afterAll(() => {
+    requestMock.mockRestore();
+})
+
+test('Throws error if response is error', async () => {
+    requestMock.mockImplementation(async () => { throw new Error("This is an error") });
+    const err = async () => { await wiki.random("some_arg") };
+    expect(err).rejects.toThrowError(Error);
+});
+
+test('Returns summary of random article', async () => {
+    requestMock.mockImplementation(async () => { return summaryJson });
+    const result = await wiki.random("summary");
+    expect(result).toStrictEqual(summaryJson);
+});
+
+test('Request includes arg provided to method', async () => {
+    requestMock.mockImplementation(async () => { return summaryJson });
+    const result = await wiki.random("summary");
+    expect(result).toStrictEqual(summaryJson);
+    expect(requestMock).toBeCalledWith(`page/random/summary`);
+});

--- a/test/random.test.ts
+++ b/test/random.test.ts
@@ -37,3 +37,10 @@ test('Request includes arg provided to method', async () => {
     expect(result).toStrictEqual(summaryJson);
     expect(requestMock).toBeCalledWith(`page/random/summary`);
 });
+
+test('Calling random with no arguments', async () => {
+    requestMock.mockImplementation(async () => { return summaryJson });
+    const result = await wiki.random();
+    expect(result).toStrictEqual(summaryJson);
+    expect(requestMock).toBeCalledWith(`page/random/summary`);
+});

--- a/test/related.test.ts
+++ b/test/related.test.ts
@@ -7,7 +7,7 @@ import { pageJson, summaryJson } from './samples';
 const requestMock = jest.spyOn(request, "makeRestRequest");
 const setTitleMock = jest.spyOn(utils, "setTitleForPage");
 
-const relatedMock = [summaryJson, summaryJson];
+const relatedMock = {pages: [summaryJson, summaryJson]};
 
 afterAll(() => {
     requestMock.mockRestore();

--- a/test/samples.ts
+++ b/test/samples.ts
@@ -145,3 +145,95 @@ export const mediaJson = {
         }]
     }]
 }
+
+export const mobileSections = {
+    lead: {
+        ns: 0,
+        id: 3449027,
+        revision: "1000443218",
+        lastmodified: "2021-01-15T03:44:53Z",
+        lastmodifier: {
+            user: "Ser Amantio di Nicolao",
+            gender: "unknown"
+        },
+        displaytitle: "<i>Girls Like Me</i>",
+        normalizedtitle: "Girls Like Me",
+        wikibase_item: "Q5564650",
+        description: "1986 studio album by Tanya Tucker",
+        description_source: "local",
+        protection: {},
+        editable: true,
+        languagecount: 1,
+        image: {
+            file: "TanyaTuckerGirlsLikeMeOriginal.jpg",
+            urls: {
+            320: "https://upload.wikimedia.org/wikipedia/en/4/48/TanyaTuckerGirlsLikeMeOriginal.jpg",
+            640: "https://upload.wikimedia.org/wikipedia/en/4/48/TanyaTuckerGirlsLikeMeOriginal.jpg",
+            800: "https://upload.wikimedia.org/wikipedia/en/4/48/TanyaTuckerGirlsLikeMeOriginal.jpg",
+            1024: "https://upload.wikimedia.org/wikipedia/en/4/48/TanyaTuckerGirlsLikeMeOriginal.jpg"
+            }
+        },
+        issues: [
+            {
+                html: "This is article",
+                text: "This is article"
+            }
+        ],
+        sections: [
+            {
+                id: 0,
+                text: "<p>This is article</p>"
+            },
+            {
+                id: 1,
+                toclevel: 1,
+                anchor: "Track_listing",
+                line: "Track listing"
+            },
+            {
+                id: 2,
+                toclevel: 1,
+                anchor: "Chart_performance",
+                line: "Chart performance"
+            }
+        ]
+    },
+    remaining: {
+        sections: [
+            {
+                id: 1,
+                text: "\n<ol><li>\"<a href=\"/wiki/One_Love_at_a_Time\" title=\"One Love at a Time\">One Love at a Time</a>\"</li></ol>",
+                toclevel: 1,
+                line: "Track listing",
+                anchor: "Track_listing"
+            },
+            {
+                id: 2,
+                text: "\n<table class=\"wikitable\">\n<tbody><tr><th>abc</th></tr></tbody></table>",
+                toclevel: 1,
+                line: "Chart performance",
+                anchor: "Chart_performance"
+            }
+        ]
+    }
+}
+
+export const title = {
+  items: [
+    {
+      title: "White-naped_seedeater",
+      page_id: 12450272,
+      rev: 1012232317,
+      tid: "fce161c0-8ea1-11eb-8f0f-a75f37ec29b6",
+      namespace: 0,
+      user_id: 40600116,
+      user_text: "ShortDescBot",
+      timestamp: "2021-03-15T09:14:24Z",
+      comment: "[[User:ShortDescBot|ShortDescBot]] adding [[Wikipedia:Short description|short description]] \"Species of bird\"",
+      tags: [],
+      restrictions: [],
+      page_language: "en",
+      redirect: false
+    }
+  ]
+}


### PR DESCRIPTION
- Get a random page from `/page/random/{format}` endpoint
- Add new result types based on return types from Wikipedia API

closes #4 