### PR TITLE
Fix requests UTF8 encoding for special characters

### DIFF
--- a/source/request.ts
+++ b/source/request.ts
@@ -1,5 +1,5 @@
 import fetch, { RequestInit } from 'node-fetch';
-import { URLSearchParams } from 'url';
+import { URLSearchParams, URL } from 'url';
 import { wikiError } from './errors';
  
 let API_URL = 'http://en.wikipedia.org/w/api.php?',

--- a/source/request.ts
+++ b/source/request.ts
@@ -1,7 +1,7 @@
 import fetch, { RequestInit } from 'node-fetch';
 import { URLSearchParams } from 'url';
 import { wikiError } from './errors';
-import URL from 'URL';
+import { URL } from 'url';
  
 let API_URL = 'http://en.wikipedia.org/w/api.php?',
     REST_API_URL = 'http://en.wikipedia.org/api/rest_v1/';

--- a/source/request.ts
+++ b/source/request.ts
@@ -1,7 +1,6 @@
 import fetch, { RequestInit } from 'node-fetch';
 import { URLSearchParams } from 'url';
 import { wikiError } from './errors';
-import { URL } from 'url';
  
 let API_URL = 'http://en.wikipedia.org/w/api.php?',
     REST_API_URL = 'http://en.wikipedia.org/api/rest_v1/';
@@ -62,7 +61,6 @@ export function setAPIUrl(prefix: string) : string {
 }
 
 export default makeRequest;
-
 
 
 

--- a/source/request.ts
+++ b/source/request.ts
@@ -1,13 +1,14 @@
 import fetch, { RequestInit } from 'node-fetch';
 import { URLSearchParams } from 'url';
 import { wikiError } from './errors';
+import URL from 'URL';
  
 let API_URL = 'http://en.wikipedia.org/w/api.php?',
     REST_API_URL = 'http://en.wikipedia.org/api/rest_v1/';
     // RATE_LIMIT = false,
     // RATE_LIMIT_MIN_WAIT = undefined,
     // RATE_LIMIT_LAST_CALL = undefined,
-    const USER_AGENT = 'wikipedia (https://github.com/dopecodez/Wikipedia/)';
+const USER_AGENT = 'wikipedia (https://github.com/dopecodez/Wikipedia/)';
 
 // Makes a request to legacy php endpoint
 async function makeRequest(params: any, redirect = true): Promise<any> {
@@ -24,7 +25,7 @@ async function makeRequest(params: any, redirect = true): Promise<any> {
                 'User-Agent': USER_AGENT
             }
         }
-        const response = await fetch(API_URL + search, options);
+        const response = await fetch(new URL(API_URL + search), options);
         const responseBuffer = await response.buffer();
         const result = JSON.parse(responseBuffer.toString());
         return result;
@@ -44,7 +45,7 @@ export async function makeRestRequest(path: string, redirect = true): Promise<an
                 'User-Agent': USER_AGENT
             }
         }
-        const response = await fetch(REST_API_URL + path, options);
+        const response = await fetch(new URL(REST_API_URL + path), options);
         const responseBuffer = await response.buffer();
         const result = JSON.parse(responseBuffer.toString());
         return result;

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -1,6 +1,7 @@
 import request, {makeRestRequest, setAPIUrl} from '../source/request';
 import * as fetch from 'node-fetch';
 import { Response } from 'node-fetch';
+import { URL } from 'url';
 import { wikiError } from '../source/errors';
 const fetchMock = jest.spyOn(fetch, "default");
 
@@ -24,7 +25,7 @@ test('makeRequest method calls and returns with expected params', async () => {
     fetchMock.mockImplementation(async () => { return response1 } );
     await request({}, true);
     expect(fetchMock).toHaveBeenCalledWith(
-        apiUrl + 'format=json&redirects=&action=query',
+        new URL(apiUrl + 'format=json&redirects=&action=query'),
         options
     );
 });
@@ -33,7 +34,7 @@ test('makeRequest method calls and returns with expected params when no value pa
     fetchMock.mockImplementation(async () => { return response3 } );
     await request({});
     expect(fetchMock).toHaveBeenCalledWith(
-        apiUrl + 'format=json&redirects=&action=query',
+        new URL(apiUrl + 'format=json&redirects=&action=query'),
         options
     );
 });
@@ -50,7 +51,7 @@ test('makeRestRequest method calls and returns with expected params', async () =
     fetchMock.mockImplementation(async () => { return response2 } );
     await makeRestRequest("path", false);
     expect(fetchMock).toHaveBeenCalledWith(
-        restApiUrl + 'path?redirect=false',
+        new URL(restApiUrl + 'path?redirect=false'),
         options
     );
 });


### PR DESCRIPTION
Add workaround to encode URL as UTF-8 fixing URLs that include special characters such as umlauts like `ö`

Source: https://github.com/node-fetch/node-fetch/issues/245