### PR TITLE
added exports to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,25 @@ const wiki = require('wikipedia');
 })();
 ```
 
+You can export types or even specific methods if you are using modern ES6 js or TypeScript.
+```js
+import wiki from 'wikipedia';
+import { wikiSummary, summaryError } from 'wikipedia';
+import { summary } from 'wikipedia';
+
+(async () => {
+	try {
+        let summary: wikiSummary; //sets the object as type wikiSummary
+		summary = await wiki.summary('Batman');
+		console.log(summary);
+        let summary2 = await summary('Batman');//using summary directly
+	} catch (error) {
+		console.log(error);
+		//=> Typeof summaryError, helpful in case you want to handle this error separately
+	}
+})();
+```
+
 ## Options
 
 All methods have options you can pass them. You can find them in [optionTypes documentation][5].

--- a/source/index.ts
+++ b/source/index.ts
@@ -589,3 +589,8 @@ export default wiki;
 // For CommonJS default export support
 module.exports = wiki;
 module.exports.default = wiki;
+
+export * from './errors';
+export * from './resultTypes';
+export * from './optionTypes';
+export * from './page';


### PR DESCRIPTION
Makes exports from default possible.

eg:
```js
import { wikiSummary, summaryError } from 'wikipedia';
import { summary } from 'wikipedia';
```