### PR TITLE
feat: add wiki.autocomplete

### DIFF
--- a/source/errors.ts
+++ b/source/errors.ts
@@ -14,6 +14,14 @@ export class searchError extends wikiError {
     }
 }
 
+export class autocompletionError extends wikiError {
+  constructor(message: string) {
+      super(message);
+      this.name = 'autocompletionError';
+  }
+}
+
+
 export class pageError extends wikiError {
     constructor(message: string) {
         super(message);

--- a/source/index.ts
+++ b/source/index.ts
@@ -6,13 +6,14 @@ import Page, {
 } from './page';
 import { coordinatesResult, eventResult, featuredContentResult, geoSearchResult, imageResult, langLinksResult, languageResult, 
     mobileSections, relatedResult, 
-    title, wikiMediaResult, wikiSearchResult, wikiSummary, notFound } from './resultTypes';
+    title, wikiMediaResult, wikiSearchResult, wikiSummary, notFound, wikiAutocompletionResult } from './resultTypes';
 import {
     categoriesError,
     contentError, coordinatesError, eventsError, fcError, geoSearchError, htmlError, imageError, infoboxError,
     introError, linksError, mediaError, pageError, relatedError, searchError, summaryError, wikiError,
     pdfError,
-    citationError
+    citationError,
+    autocompletionError
 } from './errors';
 import { MSGS } from './messages';
 import { getCurrentDay, getCurrentMonth, getCurrentYear, setPageId, setPageIdOrTitleParam, setTitleForPage } from './utils';
@@ -56,6 +57,34 @@ wiki.search = async (query: string, searchOptions?: searchOptions): Promise<wiki
     } catch (error) {
         throw new searchError(error);
     }
+}
+
+/**
+ * Returns the search results for a given query
+ *
+ * @remarks
+ * Limits results by default to 10
+ *
+ * @param query - The string to search for
+ * @param autocompletionOptions - The number of results and if suggestion needed {@link autocompletionOptions | autocompletionOptions }
+ * @returns an array of {@link wikiSearchResult | wikiAutocompletionResult }
+ */
+ wiki.autocomplete = async (query: string, autocompletionOptions?: searchOptions): Promise<wikiAutocompletionResult> => {
+  try {
+      const autocompletionParams: any = {
+          'list': 'search',
+          'limit': autocompletionOptions?.limit || 10,
+          'search': query,
+          'action': 'opensearch',
+          'redirect': 'return'
+      }
+
+      const [_, autocompletions] = await request(autocompletionParams, false);
+
+      return autocompletions;
+  } catch (error) {
+      throw new autocompletionError(error);
+  }
 }
 
 /**

--- a/source/optionTypes.ts
+++ b/source/optionTypes.ts
@@ -3,6 +3,10 @@ export interface searchOptions {
     suggestion?: boolean
 }
 
+export interface autocompletionOptions {
+  limit?: number
+}
+
 export interface pageOptions {
     autoSuggest?: boolean
     redirect?: boolean

--- a/source/resultTypes.ts
+++ b/source/resultTypes.ts
@@ -3,6 +3,8 @@ export interface wikiSearchResult {
   suggestion: string
 }
 
+export type wikiAutocompletionResult = string[]
+
 export interface pageResult {
   pageid: number,
   ns: number,

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -69,7 +69,7 @@ test('Search returns results as wikiSearchResult with suggestions as null', asyn
     });
 });
 
-test('Autocompletes returns results as wikiSearchResult', async () => {
+test('Autocomplete returns results as wikiAutocompletionResults', async () => {
   requestMock.mockImplementation(async () => {
       return ["Test", ["Test", "Testosterone", "Testicle", "Test cricket", "Test-driven development", "Testosterone (medication)", "Testicular cancer", "Tests of general relativity", "Test (wrestler)", "Test of English as a Foreign Language"]]
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -69,6 +69,18 @@ test('Search returns results as wikiSearchResult with suggestions as null', asyn
     });
 });
 
+test('Autocompletes returns results as wikiSearchResult', async () => {
+  requestMock.mockImplementation(async () => {
+      return ["Test", ["Test", "Testosterone", "Testicle", "Test cricket", "Test-driven development", "Testosterone (medication)", "Testicular cancer", "Tests of general relativity", "Test (wrestler)", "Test of English as a Foreign Language"]]
+
+  });
+  const result = await wiki.autocomplete("Test");
+
+  expect(result).toStrictEqual(
+    ["Test", "Testosterone", "Testicle", "Test cricket", "Test-driven development", "Testosterone (medication)", "Testicular cancer", "Tests of general relativity", "Test (wrestler)", "Test of English as a Foreign Language"]
+  );
+});
+
 test('Throws page error if result doesnt have page', async () => {
     requestMock.mockImplementation(async () => { return { } });
     const t = async () => {


### PR DESCRIPTION
fetches autocompletions from the OpenSearch-API

`await wiki.autocomplete('test')`
results in 
`["Test", "Testosterone", "Testicle", "Test cricket", "Test-driven development", "Testosterone (medication)", "Testicular cancer", "Tests of general relativity", "Test (wrestler)", "Test of English as a Foreign Language"]`