### PR TITLE
Allow to customize the user agent

### DIFF
--- a/source/request.ts
+++ b/source/request.ts
@@ -6,7 +6,7 @@ let API_URL = 'https://en.wikipedia.org/w/api.php?',
     // RATE_LIMIT = false,
     // RATE_LIMIT_MIN_WAIT = undefined,
     // RATE_LIMIT_LAST_CALL = undefined,
-const USER_AGENT = 'wikipedia (https://github.com/dopecodez/Wikipedia/)';
+const USER_AGENT = process.env.WIKIPEDIA_USER_AGENT || 'wikipedia (https://github.com/dopecodez/Wikipedia/)';
 
 // Makes a request to legacy php endpoint
 async function makeRequest(params: any, redirect = true): Promise<any> {


### PR DESCRIPTION
See https://meta.wikimedia.org/wiki/User-Agent_policy.  Set the environment variable `WIKIPEDIA_USER_AGENT` to override the default.