### PR TITLE
Fix undefined behaviour for pages with numbers as title (e.g 7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wikipedia",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A JavaScript wrapper for the wikipedia apis",
   "main": "dist",
   "engines": {

--- a/source/utils.ts
+++ b/source/utils.ts
@@ -4,7 +4,7 @@ import { MSGS } from "./messages";
 
 //check if input is string
 export function isString(title: any){
-    return isNaN(title);
+    return typeof title === 'string' || title instanceof String;
 }
 
 //set title for page in case autoSuggest is true


### PR DESCRIPTION
When requesting the page "23", it is expected to receive this page: https://en.wikipedia.org/wiki/23
Expected behavior:
`wiki.page("23") -> https://en.wikipedia.org/wiki/23`
`wiki.page(23) -> https://en.wikipedia.org/wiki/Assistive_technology`

Actual behavior:
`wiki.page("23") -> https://en.wikipedia.org/wiki/Assistive_technology` (which has ID 23)
`wiki.page(23) -> https://en.wikipedia.org/wiki/Assistive_technology`

So there is no way to get the page for the number 23 or for example years like 1939, sine they will be treated as IDs.

It is checked whether an ID or a Title is given by `isNaN(title)` in utils.ts, the String "7" will be handled like a page ID.
Instead check the actual type of what the function receives:
`return typeof title === 'string' || title instanceof String;`

New behavior:
`wiki.page("23") -> https://en.wikipedia.org/wiki/23`
`wiki.page(23) -> https://en.wikipedia.org/wiki/Assistive_technology`

-> Supply a number, get a page by ID, supply a string, get the page by title