### PR TITLE
protect against the scenario when langlinks is undefined

### DIFF
--- a/source/page.ts
+++ b/source/page.ts
@@ -665,7 +665,7 @@ export const langLinks = async (title: string, listOptions?: listOptions): Promi
         languageOptions = setPageIdOrTitleParam(languageOptions, title);
         const response = await request(languageOptions, listOptions?.redirect);
         const pageId = setPageId(languageOptions, response);
-        const result = response.query.pages[pageId].langlinks.map((link: any) => {
+        const result = (response.query.pages[pageId].langlinks ?? []).map((link: any) => {
             return {
                 lang: link.lang,
                 title: link['*'],

--- a/test/langlinks.test.ts
+++ b/test/langlinks.test.ts
@@ -58,6 +58,12 @@ test('Returns empty if no lang links are available', async () => {
     expect(result).toStrictEqual([]);
 });
 
+test('Returns empty if lang links object itself is not available', async () => {
+    requestMock.mockImplementation(async () => { return { query: { pages: {404: {}} } } });
+    const result = await langLinks("Test");
+    expect(result).toStrictEqual([]);
+});
+
 test('Returns with results an array of langLinksResult object', async () => {
     requestMock.mockImplementation(async () => { return { query: { pages: langLinkskMock } } });
     const result = await langLinks("Test");


### PR DESCRIPTION
For some pages, the langLinks property is undefined, and the current implementation throws an error. An example:
```
import wiki from 'wikipedia'
const pageObj = await wiki.page('TheBrain')
const langLinks = await pageObj.langLinks()
```
throws the error:
```
linksError: linksError: TypeError: Cannot read properties of undefined (reading 'map')
    at Page.langLinks (...node_modules\wikipedia\dist\page.js:234:23)
```

This PR is so that langLinks() returns an empty array rather than throws an error.